### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run Feature Flag Python SDK on TestMu AI (Formerly LambdaTest)
+﻿# Run Python Tests with LambdaTest Feature Flag SDK on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -19,8 +19,8 @@ With TestMu AI (Formerly LambdaTest), you can use the Feature Flag Python SDK to
 
 - Python 3.6 or newer
 - pip
-- A TestMu AI account. [Sign up for free](https://www.testmuai.com/register/).
-- TestMu AI `Username` and `Access Key` from the [TestMu AI Automation Dashboard](https://automation.testmuai.com/).
+- A TestMu AI account. Sign up for free.
+- TestMu AI `Username` and `Access Key` from the TestMu AI Automation Dashboard.
 
 ### Setup
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.