### PR TITLE
fix: Replace LambdaTest brand name with TestMu AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-﻿# Run Python Tests with LambdaTest Feature Flag SDK on TestMu AI (Formerly LambdaTest)
+﻿# Run Python Tests with TestMu AI Feature Flag SDK on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -10,7 +10,7 @@
 
 [TestMu AI](https://www.testmuai.com/) (Formerly LambdaTest) is the world's first full-stack AI Agentic Quality Engineering platform that empowers teams to test intelligently, smarter, and ship faster. Built for scale, it offers a full-stack testing cloud with 10K+ real devices and 3,000+ browsers. With AI-native test management, MCP servers, and agent-based automation, TestMu AI supports Selenium, Appium, Playwright, and all major frameworks. 
 
-With TestMu AI (Formerly LambdaTest), you can use the Feature Flag Python SDK to manage feature flags in your Python applications and testing workflows. This sample shows how to configure and use the LambdaTest Feature Flag Python SDK.
+With TestMu AI (Formerly LambdaTest), you can use the Feature Flag Python SDK to manage feature flags in your Python applications and testing workflows. This sample shows how to configure and use the TestMu AI (Formerly LambdaTest) Feature Flag Python SDK.
 
 - [Sign up on TestMu AI](https://www.testmuai.com/register/) (Formerly LambdaTest).
 - Follow the [TestMu AI Documentation](https://www.testmuai.com/support/docs/) for the full setup walkthrough.


### PR DESCRIPTION
Replaces all standalone LambdaTest brand mentions with TestMu AI (Formerly LambdaTest) in body text and TestMu AI in H1 title. Code blocks, URLs, badge HTML, and boilerplate are untouched.